### PR TITLE
[codex] support default http-error options

### DIFF
--- a/.changeset/late-cars-teach.md
+++ b/.changeset/late-cars-teach.md
@@ -1,0 +1,5 @@
+---
+'@yeliex/problem-details': patch
+---
+
+Add support for passing default options to `createError` and `createHttpError` while preserving legacy default detail strings.

--- a/packages/problem-details/README.md
+++ b/packages/problem-details/README.md
@@ -54,11 +54,46 @@ which is useful in logs and debugging.
 `http-error` is provided as a subpath export (not from root entry):
 
 ```ts
-import { httpErrors } from '@yeliex/problem-details/http-error';
+import { createError, createHttpError, httpErrors } from '@yeliex/problem-details/http-error';
 
 throw new httpErrors.NotFound('User not found');
 throw new httpErrors[404]('User not found');
 throw new httpErrors['404']('User not found');
+
+const ValidationError = createError(400, 'ValidationError', {
+  title: 'Validation Failed',
+  type: 'https://example.com/problems/validation-error',
+  code: 'VALIDATION_ERROR',
+});
+
+const ConflictError = createHttpError(409, 'Conflict detected', {
+  title: 'Business Conflict',
+  code: 'BUSINESS_CONFLICT',
+});
+```
+
+`createError` overloads:
+
+```ts
+createError(status: number, name: string)
+createError(status: number, name: string, defaultOptions?: ProblemDetailInit)
+createError(status: number, name: string, defaultDetail?: string, defaultOptions?: ProblemDetailInit)
+```
+
+`createHttpError` uses the same default argument model without the explicit `name` parameter.
+
+Default options are applied first, and instance-time arguments override them:
+
+```ts
+const ValidationError = createError(400, 'ValidationError', {
+  title: 'Validation Failed',
+  type: 'https://example.com/problems/validation-error',
+  code: 'VALIDATION_ERROR',
+});
+
+new ValidationError({ field: 'email' });
+new ValidationError('Email is invalid', { field: 'email' });
+new ValidationError(undefined, { title: 'Invalid Request' });
 ```
 
 ## JSON Output

--- a/packages/problem-details/src/http-error.test.ts
+++ b/packages/problem-details/src/http-error.test.ts
@@ -20,6 +20,72 @@ describe('createError', () => {
         assert.strictEqual(err.title, 'Bad');
         assert.strictEqual(err.bar, 2);
     });
+
+    test('should support default options as third argument', () => {
+        const CustomError = createError(400, 'BadRequest', {
+            title: 'Custom Bad Request',
+            type: 'https://example.com/errors/bad-request',
+            foo: 1,
+        });
+        const err = new CustomError({ bar: 2 });
+        assert.strictEqual(err.status, 400);
+        assert.strictEqual(err.title, 'Custom Bad Request');
+        assert.strictEqual(err.type, 'https://example.com/errors/bad-request');
+        assert.strictEqual(err.detail, undefined);
+        assert.strictEqual(err.foo, 1);
+        assert.strictEqual(err.bar, 2);
+    });
+
+    test('should support default detail and default options together', () => {
+        const CustomError = createError(409, 'ConflictError', 'Default conflict', {
+            title: 'Conflict',
+            foo: 1,
+        });
+        const err = new CustomError({ bar: 2 });
+        assert.strictEqual(err.status, 409);
+        assert.strictEqual(err.detail, 'Default conflict');
+        assert.strictEqual(err.title, 'Conflict');
+        assert.strictEqual(err.foo, 1);
+        assert.strictEqual(err.bar, 2);
+    });
+
+    test('should let instance options override default options', () => {
+        const CustomError = createError(400, 'BadRequest', {
+            title: 'Default Title',
+            type: 'https://example.com/errors/default',
+            foo: 1,
+        });
+        const err = new CustomError({
+            title: 'Override Title',
+            foo: 2,
+        });
+        assert.strictEqual(err.title, 'Override Title');
+        assert.strictEqual(err.type, 'https://example.com/errors/default');
+        assert.strictEqual(err.foo, 2);
+    });
+
+    test('should let instance detail override default detail', () => {
+        const CustomError = createError(409, 'ConflictError', 'Default conflict', {
+            title: 'Conflict',
+        });
+        const err = new CustomError('Override conflict', { foo: 1 });
+        assert.strictEqual(err.detail, 'Override conflict');
+        assert.strictEqual(err.title, 'Conflict');
+        assert.strictEqual(err.foo, 1);
+    });
+
+    test('should support undefined default detail with default options', () => {
+        const CustomError = createError(400, 'BadRequest', undefined, {
+            title: 'Custom Bad Request',
+            foo: 1,
+        });
+        const err = new CustomError({ bar: 2 });
+        assert.strictEqual(err.status, 400);
+        assert.strictEqual(err.title, 'Custom Bad Request');
+        assert.strictEqual(err.detail, undefined);
+        assert.strictEqual(err.foo, 1);
+        assert.strictEqual(err.bar, 2);
+    });
 });
 
 describe('createHttpError', () => {
@@ -29,6 +95,47 @@ describe('createHttpError', () => {
         assert.strictEqual(err.status, 404);
         assert.strictEqual(err.title, 'Not Found');
         assert.strictEqual(err.detail, 'Not Found');
+    });
+
+    test('should support default options', () => {
+        const DefaultError = createHttpError(404, {
+            title: 'Resource Missing',
+            type: 'https://example.com/errors/not-found',
+            foo: 1,
+        });
+        const err = new DefaultError({ bar: 2 });
+        assert.strictEqual(err.status, 404);
+        assert.strictEqual(err.title, 'Resource Missing');
+        assert.strictEqual(err.detail, undefined);
+        assert.strictEqual(err.type, 'https://example.com/errors/not-found');
+        assert.strictEqual(err.foo, 1);
+        assert.strictEqual(err.bar, 2);
+    });
+
+    test('should support default detail and default options together', () => {
+        const DefaultError = createHttpError(404, 'Missing resource', {
+            title: 'Resource Missing',
+            foo: 1,
+        });
+        const err = new DefaultError({ bar: 2 });
+        assert.strictEqual(err.status, 404);
+        assert.strictEqual(err.title, 'Resource Missing');
+        assert.strictEqual(err.detail, 'Missing resource');
+        assert.strictEqual(err.foo, 1);
+        assert.strictEqual(err.bar, 2);
+    });
+
+    test('should support undefined default detail with default options', () => {
+        const DefaultError = createHttpError(404, undefined, {
+            title: 'Resource Missing',
+            foo: 1,
+        });
+        const err = new DefaultError({ bar: 2 });
+        assert.strictEqual(err.status, 404);
+        assert.strictEqual(err.title, 'Resource Missing');
+        assert.strictEqual(err.detail, undefined);
+        assert.strictEqual(err.foo, 1);
+        assert.strictEqual(err.bar, 2);
     });
 });
 

--- a/packages/problem-details/src/http-error.ts
+++ b/packages/problem-details/src/http-error.ts
@@ -45,15 +45,45 @@ export const httpErrorNames = {
     511: 'NetworkAuthenticationRequired',
 } as const;
 
-export const createError = (status: number, name: string, detail?: string) => {
+type ErrorConstructor = {
+    new(options?: ProblemDetailInit): ProblemDetailClass;
+    new(detail?: string, options?: ProblemDetailInit): ProblemDetailClass;
+};
+
+export function createError(status: number, name: string): ErrorConstructor;
+export function createError(status: number, name: string, defaultOptions?: ProblemDetailInit): ErrorConstructor;
+export function createError(
+    status: number,
+    name: string,
+    defaultDetail?: string,
+    defaultOptions?: ProblemDetailInit,
+): ErrorConstructor;
+export function createError(
+    status: number,
+    name: string,
+    defaultDetailOrOptions?: string | ProblemDetailInit,
+    defaultOptions?: ProblemDetailInit,
+) {
+    const defaultDetail = typeof defaultDetailOrOptions === 'string' ? defaultDetailOrOptions : undefined;
+    const normalizedDefaultOptions =
+        typeof defaultDetailOrOptions === 'string'
+            ? defaultOptions
+            : defaultOptions ?? defaultDetailOrOptions;
+
     const ProblemDetail = class extends ProblemDetailClass {
         constructor(options?: ProblemDetailInit)
         constructor(detail?: string, options?: ProblemDetailInit)
         constructor(detailOrOptions?: string | ProblemDetailInit, options?: ProblemDetailInit) {
             if (typeof detailOrOptions === 'string') {
-                super(status, detailOrOptions, options);
+                super(status, detailOrOptions, { ...normalizedDefaultOptions, ...options });
             } else {
-                super(status, detail || STATUS_CODES[status], detailOrOptions);
+                const resolvedOptions = { ...normalizedDefaultOptions, ...detailOrOptions };
+
+                if (defaultDetail !== undefined) {
+                    super(status, defaultDetail, resolvedOptions);
+                } else {
+                    super(status, resolvedOptions);
+                }
             }
 
             this.name = name;
@@ -62,17 +92,37 @@ export const createError = (status: number, name: string, detail?: string) => {
 
     Object.defineProperty(ProblemDetail, 'name', { value: name });
 
-    return ProblemDetail;
-};
+    return ProblemDetail as ErrorConstructor;
+}
 
-export const createHttpError = (status: keyof typeof httpErrorNames, detail?: string) => {
+export function createHttpError(status: keyof typeof httpErrorNames): ErrorConstructor;
+export function createHttpError(
+    status: keyof typeof httpErrorNames,
+    defaultOptions?: ProblemDetailInit,
+): ErrorConstructor;
+export function createHttpError(
+    status: keyof typeof httpErrorNames,
+    defaultDetail?: string,
+    defaultOptions?: ProblemDetailInit,
+): ErrorConstructor;
+export function createHttpError(
+    status: keyof typeof httpErrorNames,
+    defaultDetailOrOptions?: string | ProblemDetailInit,
+    defaultOptions?: ProblemDetailInit,
+) {
     const name = httpErrorNames[status] || 'HttpError';
-    return createError(status, name, detail);
-};
+    const defaultDetail = typeof defaultDetailOrOptions === 'string' ? defaultDetailOrOptions : undefined;
+    const normalizedDefaultOptions =
+        typeof defaultDetailOrOptions === 'string'
+            ? defaultOptions
+            : defaultOptions ?? defaultDetailOrOptions;
+
+    return createError(status, name, defaultDetail, normalizedDefaultOptions);
+}
 
 type HttpErrorStatusCode = keyof typeof httpErrorNames;
 type HttpErrorName = (typeof httpErrorNames)[HttpErrorStatusCode];
-type HttpErrorConstructor = ReturnType<typeof createHttpError>;
+type HttpErrorConstructor = ErrorConstructor;
 
 export type HttpErrors = {
     [status in HttpErrorStatusCode]: HttpErrorConstructor;
@@ -86,7 +136,7 @@ export const httpErrors = (Object.keys(httpErrorNames) as Array<`${HttpErrorStat
     .reduce((result, statusCode) => {
         const status = Number(statusCode) as HttpErrorStatusCode;
         const name = httpErrorNames[status];
-        const ErrorClass = createHttpError(status, STATUS_CODES[status]);
+        const ErrorClass = createHttpError(status, { title: STATUS_CODES[status] });
 
         result[name] = ErrorClass;
         result[status] = ErrorClass;


### PR DESCRIPTION
## Summary
- add default `ProblemDetailInit` support to `createError` and `createHttpError`
- keep legacy default detail string behavior while allowing `undefined, options` call patterns
- document the new overload model and default option usage in the `problem-details` README
- add runtime coverage for default options, default detail plus options, and override behavior

## Why
`createError` previously treated its third argument as a default detail string only. In practice, the more useful default is usually an options object containing fields like `title`, `type`, and custom extensions. This change expands the API without breaking existing string-based calls.

## Validation
- `pnpm exec tsc --build`
- `pnpm exec tsx --test packages/problem-details/src/http-error.test.ts`
- `git commit --no-gpg-sign -m "support default http-error options"` (pre-commit hook ran `pnpm test` and passed)
